### PR TITLE
API tests

### DIFF
--- a/src/main/java/com/historycode/api/clients/BaseClient.java
+++ b/src/main/java/com/historycode/api/clients/BaseClient.java
@@ -19,19 +19,16 @@ public class BaseClient {
     public BaseClient(String baseUrl) {
         this.baseAPIUrl = baseUrl;
         contentType = ContentType.JSON;
-        registerCustomParser();
     }
 
     public BaseClient(String baseUrl, ContentType contentType) {
         this.baseAPIUrl = baseUrl;
         this.contentType = contentType;
-        registerCustomParser();
     }
 
     public BaseClient(String baseUrl, String contentType) {
         this.baseAPIUrl = baseUrl;
         this.contentType = ContentType.valueOf(contentType);
-        registerCustomParser();
     }
 
 
@@ -45,7 +42,4 @@ public class BaseClient {
         return request;
     }
 
-    private void registerCustomParser() {
-        RestAssured.registerParser("application/problem+json", Parser.JSON);
-    }
 }

--- a/src/main/java/com/historycode/api/clients/NewsClient.java
+++ b/src/main/java/com/historycode/api/clients/NewsClient.java
@@ -68,10 +68,4 @@ public class NewsClient extends BaseClient {
                 .delete(resourceUrl + "/Delete/" + newsId);
     }
 
-    public Response updateNews(NewsResponse news) {
-        return preparedRequest()
-                .when()
-                .body(news)
-                .put(resourceUrl + "/Update");
-    }
 }

--- a/src/test/java/com/historycode/api/adminPanel/news/APINewsTest.java
+++ b/src/test/java/com/historycode/api/adminPanel/news/APINewsTest.java
@@ -96,7 +96,7 @@ public class APINewsTest extends ApiTestRunner {
         int newsId = newsList.getFirst().getId();
         int imageId = newsList.getFirst().getImage().getId();
 
-        NewsResponse updatedNews = new NewsResponse();
+        NewsUpdateRequestBody updatedNews = new NewsUpdateRequestBody();
         updatedNews.setId(newsId);
         updatedNews.setTitle("News KH");
         updatedNews.setText("News Testing");
@@ -104,7 +104,7 @@ public class APINewsTest extends ApiTestRunner {
         updatedNews.setUrl("news");
         updatedNews.setCreationDate(Instant.now().toString());
 
-        Response updateResponse = newsClient.updateNews(updatedNews);
+        Response updateResponse = newsClient.update(updatedNews);
         softAssert.assertEquals(updateResponse.getStatusCode(), 200, "News update failed");
 
         Response updatedNewsData = newsClient.getById(newsId);

--- a/src/test/java/com/historycode/api/adminPanel/news/BaseNewsTests.java
+++ b/src/test/java/com/historycode/api/adminPanel/news/BaseNewsTests.java
@@ -98,7 +98,7 @@ public class BaseNewsTests extends ApiTestRunner {
         return new String(result);
     }
 
-    protected void checkError200StatusCode(Response response) {
+    protected void checkUnexpected200StatusCode(Response response) {
         if (response.getStatusCode() == 200) {
             NewsResponse newsResponse = response.body().as(NewsResponse.class);
             setDeleteId(newsResponse.getId());

--- a/src/test/java/com/historycode/api/adminPanel/news/BaseNewsTests.java
+++ b/src/test/java/com/historycode/api/adminPanel/news/BaseNewsTests.java
@@ -3,10 +3,13 @@ package com.historycode.api.adminPanel.news;
 import com.historycode.api.clients.ImageClient;
 import com.historycode.api.clients.NewsClient;
 import com.historycode.api.models.adminPanel.news.NewsRequestBody;
+import com.historycode.api.models.adminPanel.news.NewsResponse;
 import com.historycode.api.models.img.ImageRequest;
 import com.historycode.api.testRunners.ApiTestRunner;
 import com.historycode.utils.ImageProcessor;
 import io.restassured.response.Response;
+import lombok.Getter;
+import lombok.Setter;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
@@ -15,12 +18,15 @@ import org.testng.annotations.BeforeMethod;
 import java.time.Instant;
 import java.util.Random;
 
+import static org.testng.Assert.assertEquals;
+
 public class BaseNewsTests extends ApiTestRunner {
-    private static final int NO_DELETE_ID = -1;
-    protected int deleteId = NO_DELETE_ID;
+    @Getter
+    @Setter
+    private Integer deleteId = null;
     protected NewsClient client;
     protected ImageClient imageClient;
-    NewsRequestBody requestBody;
+    protected NewsRequestBody requestBody;
 
     @BeforeClass
     public void setUpClass() {
@@ -31,51 +37,72 @@ public class BaseNewsTests extends ApiTestRunner {
 
     @BeforeMethod
     public void initNewsRequest() {
-        requestBody = new NewsRequestBody();
-        requestBody.setTitle("Test News Item");
-        requestBody.setText("News Item Testing");
-        requestBody.setImageId(createNewImg());
-        requestBody.setUrl("news-item");
-        requestBody.setCreationDate(Instant.now().toString());
+        requestBody = createNewsRequest();
     }
 
     @AfterMethod
     public void tearDownMethod() {
-        if (deleteId != NO_DELETE_ID) {
+        if (getDeleteId() != null) {
             try {
-                client.delete(deleteId);
+                Response deleteResponse = client.delete(getDeleteId());
+                assertEquals(deleteResponse.getStatusCode(), 200,
+                        String.format("The test news item with ID %s was not deleted.", getDeleteId()));
             } finally {
-                deleteId = NO_DELETE_ID;
+                setDeleteId(null);
             }
         }
     }
 
-    public static String generateRandomAlphanumeric(int length) {
-        String characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-        StringBuilder result = new StringBuilder(length);
-        Random random = new Random();
+    private NewsRequestBody createNewsRequest() {
+        long timestamp = Instant.now().toEpochMilli();
 
-        for (int i = 0; i < length; i++) {
-            result.append(characters.charAt(random.nextInt(characters.length())));
-        }
+        requestBody = new NewsRequestBody();
+        requestBody.setTitle("Test News Item " + timestamp);
+        requestBody.setText("News Item Testing " + timestamp);
+        requestBody.setImageId(createNewImg());
+        requestBody.setUrl("news-item-" + timestamp);
 
-        return result.toString();
+        return requestBody;
     }
 
-    protected int createNewImg() {
+    private int createNewImg() {
         ImageClient imageClient = new ImageClient(testValueProvider.getBaseAPIUrl());
         ImageRequest newsImage = new ImageRequest();
 
-        newsImage.setTitle("TempImg" + System.currentTimeMillis());
+        newsImage.setTitle("TestImg" + Instant.now().toEpochMilli());
         newsImage.setBaseFormat(ImageProcessor.encodeImage("src/test/resources/newsTest.png"));
         newsImage.setMimeType("image/png");
         newsImage.setExtension("png");
         newsImage.setAlt("1");
 
         Response response = imageClient.post(newsImage);
-        Assert.assertEquals(response.getStatusCode(), 200, "Image was not created");
+        Assert.assertEquals(response.getStatusCode(), 200,
+                "The test image item was not created.");
 
         return response.getBody().jsonPath().getInt("id");
+    }
+
+    protected static String generateRandomAlphanumeric(int length) {
+        if (length <= 0) {
+            throw new IllegalArgumentException("Length must be greater than 0");
+        }
+
+        String characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+        char[] result = new char[length];
+        Random random = new Random();
+
+        for (int i = 0; i < length; i++) {
+            result[i] = characters.charAt(random.nextInt(characters.length()));
+        }
+
+        return new String(result);
+    }
+
+    protected void checkError200StatusCode(Response response) {
+        if (response.getStatusCode() == 200) {
+            NewsResponse newsResponse = response.body().as(NewsResponse.class);
+            setDeleteId(newsResponse.getId());
+        }
     }
 
 }

--- a/src/test/java/com/historycode/api/adminPanel/news/BaseNewsTests.java
+++ b/src/test/java/com/historycode/api/adminPanel/news/BaseNewsTests.java
@@ -67,9 +67,9 @@ public class BaseNewsTests extends ApiTestRunner {
         ImageRequest newsImage = new ImageRequest();
 
         newsImage.setTitle("TempImg" + System.currentTimeMillis());
-        newsImage.setBaseFormat(ImageProcessor.encodeImage("src/test/resources/logo.jpeg"));
-        newsImage.setMimeType("image/jpeg");
-        newsImage.setExtension("jpeg");
+        newsImage.setBaseFormat(ImageProcessor.encodeImage("src/test/resources/newsTest.png"));
+        newsImage.setMimeType("image/png");
+        newsImage.setExtension("png");
         newsImage.setAlt("1");
 
         Response response = imageClient.post(newsImage);

--- a/src/test/java/com/historycode/api/adminPanel/news/NewsNegativeTests.java
+++ b/src/test/java/com/historycode/api/adminPanel/news/NewsNegativeTests.java
@@ -33,6 +33,7 @@ public class NewsNegativeTests extends BaseNewsTests {
 
         Response response = client.create(requestBody);
 
+        checkError200StatusCode(response);
         assertEquals(response.getStatusCode(), 400);
         assertEquals(response.path("errors.Title[0]"), "Max Length is 100",
                 "Error message is incorrect");
@@ -47,6 +48,7 @@ public class NewsNegativeTests extends BaseNewsTests {
 
         Response response = client.create(requestBody);
 
+        checkError200StatusCode(response);
         assertEquals(response.getStatusCode(), 400);
         assertEquals(response.path("errors.URL[0]"), "Max Length is 200",
                 "Error message is incorrect");
@@ -61,10 +63,11 @@ public class NewsNegativeTests extends BaseNewsTests {
 
         Response response = client.create(requestBody);
 
+        checkError200StatusCode(response);
         assertEquals(response.getStatusCode(), 400);
-        System.out.println(response.body().asPrettyString());
         assertTrue(response.body().asPrettyString().contains("Url Is Invalid"),
                 "Error message is incorrect");
+        checkError200StatusCode(response);
     }
 
     @Issue("202")
@@ -76,6 +79,7 @@ public class NewsNegativeTests extends BaseNewsTests {
 
         Response response = client.create(requestBody);
 
+        checkError200StatusCode(response);
         assertEquals(response.getStatusCode(), 400);
         assertTrue(response.body().asPrettyString().contains("Url Is Invalid"),
                 "Error message is incorrect");
@@ -90,6 +94,7 @@ public class NewsNegativeTests extends BaseNewsTests {
 
         Response response = client.create(requestBody);
 
+        checkError200StatusCode(response);
         assertEquals(response.getStatusCode(), 400);
         assertTrue(response.body().asPrettyString().contains("Url Is Invalid"),
                 "Error message is incorrect");
@@ -104,6 +109,7 @@ public class NewsNegativeTests extends BaseNewsTests {
 
         Response response = client.create(requestBody);
 
+        checkError200StatusCode(response);
         assertEquals(response.getStatusCode(), 400);
         assertEquals(response.path("errors.Text[0]"), "Max Length is 15000",
                 "Error message is incorrect");
@@ -118,6 +124,7 @@ public class NewsNegativeTests extends BaseNewsTests {
 
         Response response = client.create(requestBody);
 
+        checkError200StatusCode(response);
         assertEquals(response.getStatusCode(), 400);
         assertTrue(response.body().asPrettyString().contains("The news cannot be published with a past date"),
                 "Error message is incorrect");
@@ -137,6 +144,13 @@ public class NewsNegativeTests extends BaseNewsTests {
         Response deleteResponse = client.delete(newsResponse.getId());
 
         assertEquals(deleteResponse.getStatusCode(), 401);
+    }
+
+    private void checkError200StatusCode(Response response) {
+        if (response.getStatusCode() == 200) {
+            NewsResponse newsResponse = response.body().as(NewsResponse.class);
+            deleteId = newsResponse.getId();
+        }
     }
 
 }

--- a/src/test/java/com/historycode/api/adminPanel/news/NewsNegativeTests.java
+++ b/src/test/java/com/historycode/api/adminPanel/news/NewsNegativeTests.java
@@ -67,7 +67,6 @@ public class NewsNegativeTests extends BaseNewsTests {
         assertEquals(response.getStatusCode(), 400);
         assertTrue(response.body().asPrettyString().contains("Url Is Invalid"),
                 "Error message is incorrect");
-        checkError200StatusCode(response);
     }
 
     @Issue("202")

--- a/src/test/java/com/historycode/api/adminPanel/news/NewsNegativeTests.java
+++ b/src/test/java/com/historycode/api/adminPanel/news/NewsNegativeTests.java
@@ -93,7 +93,7 @@ public class NewsNegativeTests extends BaseNewsTests {
     @Description("Verify that the news cannot be created with special symbols ($,@,%,#) in 'url' field using POST method")
     public void testVerifyCreationWithSpecialSymbolsInUrl(String url) {
 
-        requestBody.setCreationDate(url);
+        requestBody.setUrl(url);
         requestBody.setCreationDate(Instant.now().toString());
 
         Response response = client.create(requestBody);
@@ -141,6 +141,7 @@ public class NewsNegativeTests extends BaseNewsTests {
     public void testVerifyDeletionWithoutAuthorizationById() {
 
         requestBody.setCreationDate(Instant.now().toString());
+
         Response response = client.create(requestBody);
 
         NewsResponse newsResponse = response.body().as(NewsResponse.class);

--- a/src/test/java/com/historycode/api/adminPanel/news/NewsNegativeTests.java
+++ b/src/test/java/com/historycode/api/adminPanel/news/NewsNegativeTests.java
@@ -34,7 +34,7 @@ public class NewsNegativeTests extends BaseNewsTests {
 
         Response response = client.create(requestBody);
 
-        checkError200StatusCode(response);
+        checkUnexpected200StatusCode(response);
         assertEquals(response.getStatusCode(), 400);
         assertEquals(response.path("errors.Title[0]"), "Max Length is 100",
                 "Error message is incorrect");
@@ -50,7 +50,7 @@ public class NewsNegativeTests extends BaseNewsTests {
 
         Response response = client.create(requestBody);
 
-        checkError200StatusCode(response);
+        checkUnexpected200StatusCode(response);
         assertEquals(response.getStatusCode(), 400);
         assertEquals(response.path("errors.URL[0]"), "Max Length is 200",
                 "Error message is incorrect");
@@ -66,7 +66,7 @@ public class NewsNegativeTests extends BaseNewsTests {
 
         Response response = client.create(requestBody);
 
-        checkError200StatusCode(response);
+        checkUnexpected200StatusCode(response);
         assertEquals(response.getStatusCode(), 400);
         assertTrue(response.body().asPrettyString().contains("Url Is Invalid"),
                 "Error message is incorrect");
@@ -82,7 +82,7 @@ public class NewsNegativeTests extends BaseNewsTests {
 
         Response response = client.create(requestBody);
 
-        checkError200StatusCode(response);
+        checkUnexpected200StatusCode(response);
         assertEquals(response.getStatusCode(), 400);
         assertTrue(response.body().asPrettyString().contains("Url Is Invalid"),
                 "Error message is incorrect");
@@ -98,7 +98,7 @@ public class NewsNegativeTests extends BaseNewsTests {
 
         Response response = client.create(requestBody);
 
-        checkError200StatusCode(response);
+        checkUnexpected200StatusCode(response);
         assertEquals(response.getStatusCode(), 400);
         assertTrue(response.body().asPrettyString().contains("Url Is Invalid"),
                 "Error message is incorrect");
@@ -114,7 +114,7 @@ public class NewsNegativeTests extends BaseNewsTests {
 
         Response response = client.create(requestBody);
 
-        checkError200StatusCode(response);
+        checkUnexpected200StatusCode(response);
         assertEquals(response.getStatusCode(), 400);
         assertEquals(response.path("errors.Text[0]"), "Max Length is 15000",
                 "Error message is incorrect");
@@ -129,7 +129,7 @@ public class NewsNegativeTests extends BaseNewsTests {
 
         Response response = client.create(requestBody);
 
-        checkError200StatusCode(response);
+        checkUnexpected200StatusCode(response);
         assertEquals(response.getStatusCode(), 400);
         assertTrue(response.body().asPrettyString().contains("The news cannot be published with a past date"),
                 "Error message is incorrect");

--- a/src/test/java/com/historycode/api/adminPanel/news/NewsNegativeTests.java
+++ b/src/test/java/com/historycode/api/adminPanel/news/NewsNegativeTests.java
@@ -126,7 +126,6 @@ public class NewsNegativeTests extends BaseNewsTests {
     public void testVerifyCreationWithPastDateInCreationDate() {
 
         requestBody.setCreationDate(Instant.now().minus(7, ChronoUnit.DAYS).toString());
-        requestBody.setCreationDate(Instant.now().toString());
 
         Response response = client.create(requestBody);
 

--- a/src/test/java/com/historycode/api/adminPanel/news/NewsNegativeTests.java
+++ b/src/test/java/com/historycode/api/adminPanel/news/NewsNegativeTests.java
@@ -30,6 +30,7 @@ public class NewsNegativeTests extends BaseNewsTests {
     public void testVerifyCreationWithExceededTitleLength() {
 
         requestBody.setTitle(generateRandomAlphanumeric(101));
+        requestBody.setCreationDate(Instant.now().toString());
 
         Response response = client.create(requestBody);
 
@@ -45,6 +46,7 @@ public class NewsNegativeTests extends BaseNewsTests {
     public void testVerifyCreationWithExceededUrlLength() {
 
         requestBody.setUrl(generateRandomAlphanumeric(201).toLowerCase());
+        requestBody.setCreationDate(Instant.now().toString());
 
         Response response = client.create(requestBody);
 
@@ -60,6 +62,7 @@ public class NewsNegativeTests extends BaseNewsTests {
     public void testVerifyCreationWithCapitalLettersInUrl() {
 
         requestBody.setUrl("News-item");
+        requestBody.setCreationDate(Instant.now().toString());
 
         Response response = client.create(requestBody);
 
@@ -75,6 +78,7 @@ public class NewsNegativeTests extends BaseNewsTests {
     public void testVerifyCreationWithCyrillicLettersInUrl() {
 
         requestBody.setUrl("новина");
+        requestBody.setCreationDate(Instant.now().toString());
 
         Response response = client.create(requestBody);
 
@@ -90,6 +94,7 @@ public class NewsNegativeTests extends BaseNewsTests {
     public void testVerifyCreationWithSpecialSymbolsInUrl(String url) {
 
         requestBody.setCreationDate(url);
+        requestBody.setCreationDate(Instant.now().toString());
 
         Response response = client.create(requestBody);
 
@@ -105,6 +110,7 @@ public class NewsNegativeTests extends BaseNewsTests {
     public void testVerifyCreationWithExceededLengthInText() {
 
         requestBody.setText(generateRandomAlphanumeric(15001));
+        requestBody.setCreationDate(Instant.now().toString());
 
         Response response = client.create(requestBody);
 
@@ -120,6 +126,7 @@ public class NewsNegativeTests extends BaseNewsTests {
     public void testVerifyCreationWithPastDateInCreationDate() {
 
         requestBody.setCreationDate(Instant.now().minus(7, ChronoUnit.DAYS).toString());
+        requestBody.setCreationDate(Instant.now().toString());
 
         Response response = client.create(requestBody);
 
@@ -134,22 +141,16 @@ public class NewsNegativeTests extends BaseNewsTests {
     @Description("Verify that the news cannot be deleted without authorization by 'id' using DELETE method")
     public void testVerifyDeletionWithoutAuthorizationById() {
 
+        requestBody.setCreationDate(Instant.now().toString());
         Response response = client.create(requestBody);
 
         NewsResponse newsResponse = response.body().as(NewsResponse.class);
-        deleteId = newsResponse.getId();
+        setDeleteId(newsResponse.getId());
 
         client.setToken(null);
         Response deleteResponse = client.delete(newsResponse.getId());
 
         assertEquals(deleteResponse.getStatusCode(), 401);
-    }
-
-    private void checkError200StatusCode(Response response) {
-        if (response.getStatusCode() == 200) {
-            NewsResponse newsResponse = response.body().as(NewsResponse.class);
-            deleteId = newsResponse.getId();
-        }
     }
 
 }

--- a/src/test/java/com/historycode/api/adminPanel/news/NewsPositiveTests.java
+++ b/src/test/java/com/historycode/api/adminPanel/news/NewsPositiveTests.java
@@ -35,7 +35,7 @@ public class NewsPositiveTests extends BaseNewsTests {
         softAssert.assertEquals(newsResponse.getText(), requestBody.getText());
         softAssert.assertEquals(newsResponse.getImageId(), requestBody.getImageId());
         softAssert.assertEquals(newsResponse.getUrl(), requestBody.getUrl());
-        softAssert.assertEquals(newsResponse.getCreationDate(), requestBody.getCreationDate());
+        softAssert.assertNotNull(newsResponse.getCreationDate());
         softAssert.assertAll();
     }
 
@@ -58,7 +58,7 @@ public class NewsPositiveTests extends BaseNewsTests {
         softAssert.assertEquals(newsResponse.getText(), requestBody.getText());
         softAssert.assertEquals(newsResponse.getImageId(), requestBody.getImageId());
         softAssert.assertEquals(newsResponse.getUrl(), requestBody.getUrl());
-        softAssert.assertEquals(newsResponse.getCreationDate(), requestBody.getCreationDate());
+        softAssert.assertNotNull(newsResponse.getCreationDate());
         softAssert.assertAll();
     }
 
@@ -81,7 +81,7 @@ public class NewsPositiveTests extends BaseNewsTests {
         softAssert.assertEquals(newsResponse.getText(), requestBody.getText());
         softAssert.assertEquals(newsResponse.getImageId(), requestBody.getImageId());
         softAssert.assertEquals(newsResponse.getUrl(), requestBody.getUrl());
-        softAssert.assertEquals(newsResponse.getCreationDate(), requestBody.getCreationDate());
+        softAssert.assertNotNull(newsResponse.getCreationDate());
         softAssert.assertAll();
     }
 
@@ -106,7 +106,7 @@ public class NewsPositiveTests extends BaseNewsTests {
         softAssert.assertEquals(newsResponse.getText(), requestBody.getText());
         softAssert.assertEquals(newsResponse.getImageId(), requestBody.getImageId());
         softAssert.assertEquals(newsResponse.getUrl(), requestBody.getUrl());
-        softAssert.assertEquals(newsResponse.getCreationDate(), requestBody.getCreationDate());
+        softAssert.assertNotNull(newsResponse.getCreationDate());
         softAssert.assertAll();
     }
 
@@ -118,7 +118,6 @@ public class NewsPositiveTests extends BaseNewsTests {
         Response response = client.create(requestBody);
 
         NewsResponse newsResponse = response.body().as(NewsResponse.class);
-        deleteId = newsResponse.getId();
 
         Response deleteResponse = client.delete(newsResponse.getId());
 

--- a/src/test/java/com/historycode/api/adminPanel/news/NewsPositiveTests.java
+++ b/src/test/java/com/historycode/api/adminPanel/news/NewsPositiveTests.java
@@ -94,7 +94,6 @@ public class NewsPositiveTests extends BaseNewsTests {
     public void testVerifyCreationWithFutureDateInCreationDate() {
 
         requestBody.setCreationDate(Instant.now().plus(7, ChronoUnit.DAYS).toString());
-        requestBody.setCreationDate(Instant.now().toString());
 
         Response response = client.create(requestBody);
 

--- a/src/test/java/com/historycode/api/adminPanel/news/NewsPositiveTests.java
+++ b/src/test/java/com/historycode/api/adminPanel/news/NewsPositiveTests.java
@@ -22,13 +22,14 @@ public class NewsPositiveTests extends BaseNewsTests {
     public void testVerifyCreationWithMaxTitleLength() {
 
         requestBody.setTitle(generateRandomAlphanumeric(100));
+        requestBody.setCreationDate(Instant.now().toString());
 
         Response response = client.create(requestBody);
 
         Assert.assertEquals(response.getStatusCode(), 200);
 
         NewsResponse newsResponse = response.body().as(NewsResponse.class);
-        deleteId = newsResponse.getId();
+        setDeleteId(newsResponse.getId());
 
         SoftAssert softAssert = new SoftAssert();
         softAssert.assertEquals(newsResponse.getTitle(), requestBody.getTitle());
@@ -45,13 +46,14 @@ public class NewsPositiveTests extends BaseNewsTests {
     public void testVerifyCreationWithMaxUrlLength() {
 
         requestBody.setUrl(generateRandomAlphanumeric(200).toLowerCase());
+        requestBody.setCreationDate(Instant.now().toString());
 
         Response response = client.create(requestBody);
 
         Assert.assertEquals(response.getStatusCode(), 200);
 
         NewsResponse newsResponse = response.body().as(NewsResponse.class);
-        deleteId = newsResponse.getId();
+        setDeleteId(newsResponse.getId());
 
         SoftAssert softAssert = new SoftAssert();
         softAssert.assertEquals(newsResponse.getTitle(), requestBody.getTitle());
@@ -68,13 +70,14 @@ public class NewsPositiveTests extends BaseNewsTests {
     public void testVerifyCreationWithMaxLengthInText() {
 
         requestBody.setText(generateRandomAlphanumeric(15000));
+        requestBody.setCreationDate(Instant.now().toString());
 
         Response response = client.create(requestBody);
 
         Assert.assertEquals(response.getStatusCode(), 200);
 
         NewsResponse newsResponse = response.body().as(NewsResponse.class);
-        deleteId = newsResponse.getId();
+        setDeleteId(newsResponse.getId());
 
         SoftAssert softAssert = new SoftAssert();
         softAssert.assertEquals(newsResponse.getTitle(), requestBody.getTitle());
@@ -91,6 +94,7 @@ public class NewsPositiveTests extends BaseNewsTests {
     public void testVerifyCreationWithFutureDateInCreationDate() {
 
         requestBody.setCreationDate(Instant.now().plus(7, ChronoUnit.DAYS).toString());
+        requestBody.setCreationDate(Instant.now().toString());
 
         Response response = client.create(requestBody);
 
@@ -98,7 +102,7 @@ public class NewsPositiveTests extends BaseNewsTests {
 
         NewsResponse newsResponse = response.body().as(NewsResponse.class);
 
-        deleteId = newsResponse.getId();
+        setDeleteId(newsResponse.getId());
 
         SoftAssert softAssert = new SoftAssert();
         assertEquals(response.path("Status"), "Запланована");
@@ -115,6 +119,7 @@ public class NewsPositiveTests extends BaseNewsTests {
     @Description("Verify that the news is deleted by 'id' using DELETE method")
     public void testVerifyDeletionById() {
 
+        requestBody.setCreationDate(Instant.now().toString());
         Response response = client.create(requestBody);
 
         NewsResponse newsResponse = response.body().as(NewsResponse.class);

--- a/src/test/java/com/historycode/api/testRunners/ApiTestRunner.java
+++ b/src/test/java/com/historycode/api/testRunners/ApiTestRunner.java
@@ -1,13 +1,17 @@
 package com.historycode.api.testRunners;
 
 import com.historycode.TestValueProvider;
+import io.restassured.RestAssured;
+import io.restassured.parsing.Parser;
 import org.testng.annotations.BeforeSuite;
 
 public class ApiTestRunner {
-    protected  static TestValueProvider testValueProvider;
+    protected static TestValueProvider testValueProvider;
 
     @BeforeSuite
-    public void setUp(){
+    public void setUp() {
         testValueProvider = new TestValueProvider();
+        RestAssured.registerParser("application/problem+json", Parser.JSON);
     }
+
 }


### PR DESCRIPTION
Delete functionality for 200 instead 400 was added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Enhanced handling of news-related tests with consistent timestamp management for creation dates.
  - Centralized status code checking logic in news tests for improved validation.
  - Updated test methods to utilize a consistent approach for setting `deleteId`.
  - Removed unnecessary response body printing in tests.
  - Adjusted news update requests to align with new data structures and method calls.
- **Chores**
  - Removed the `updateNews` method from the API client, simplifying the update process.
  - Registered a parser for handling specific media types in API responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->